### PR TITLE
Add include guards and fix ambiguous typedefs

### DIFF
--- a/mqtt-msg.h
+++ b/mqtt-msg.h
@@ -31,6 +31,9 @@
 
 #include <stdint.h>
 
+#ifndef MQTT_MSG_H_
+#define MQTT_MSG_H_
+
 enum mqtt_message_type
 {
   MQTT_MSG_TYPE_CONNECT     = 1,
@@ -49,14 +52,14 @@ enum mqtt_message_type
   MQTT_MSG_TYPE_DISCONNECT  = 14
 };
 
-typedef struct mqtt_message
+typedef struct
 {
   uint8_t* data;
   uint16_t length;
 
 } mqtt_message_t;
 
-typedef struct mqtt_connection
+typedef struct
 {
   mqtt_message_t message;
 
@@ -104,3 +107,4 @@ mqtt_message_t* mqtt_msg_pingreq(mqtt_connection_t* connection);
 mqtt_message_t* mqtt_msg_pingresp(mqtt_connection_t* connection);
 mqtt_message_t* mqtt_msg_disconnect(mqtt_connection_t* connection);
 
+#endif

--- a/mqtt-service.h
+++ b/mqtt-service.h
@@ -29,6 +29,11 @@
  *
  */
 
+#ifndef MQTT_SERVICE_H_
+#define MQTT_SERVICE_H_
+
+#include <stdio.h>
+#include "uip.h"
 #include "mqtt-msg.h"
 
 #define MQTT_FLAG_CONNECTED          1
@@ -178,4 +183,4 @@ static inline uint16_t mqtt_event_get_data_offset(void* data)
   return ((mqtt_event_data_t*)data)->data_offset;
 }
 
-
+#endif


### PR DESCRIPTION
In order to prevent multiple includes from causing a whole bunch of "multiple defines" errors include guards should be added.

Also when compiling I got some error messages stating redefines of mqtt_message and mqtt_connection. For this reason this I switched the typedefs to use anonymous structs.
